### PR TITLE
leaderboard scrollbar styles

### DIFF
--- a/alpaca_arcade/static/overview.css
+++ b/alpaca_arcade/static/overview.css
@@ -56,7 +56,9 @@ h1 {
     gap: 10px;
     color: white;
     width: 40vw;
-    overflow: scroll;
+    overflow-y: scroll;
+    scrollbar-width: thin;
+    scrollbar-color: var(--theme-light) transparent;
     height: 30vh;
     align-items: center;
     justify-content: space-evenly;


### PR DESCRIPTION
* remove horizontal scrollbar
* make vertical scrollbar thin and green without background
* now there's no overlap with the border